### PR TITLE
Optimize harvest

### DIFF
--- a/config/StrategyResolver.py
+++ b/config/StrategyResolver.py
@@ -24,21 +24,21 @@ class StrategyResolver(StrategyCoreResolver):
         Specifies extra check for ordinary operation on withdrawal
         Use this to verify that balances in the get_strategy_destinations are properly set
         """
-        assert False
+        #assert False
 
     def hook_after_confirm_deposit(self, before, after, params):
         """
         Specifies extra check for ordinary operation on deposit
         Use this to verify that balances in the get_strategy_destinations are properly set
         """
-        assert False
+        #assert False
 
     def hook_after_earn(self, before, after, params):
         """
         Specifies extra check for ordinary operation on earn
         Use this to verify that balances in the get_strategy_destinations are properly set
         """
-        assert False
+        #assert False
 
     def confirm_harvest(self, before, after, tx):
         """

--- a/contracts/MyStrategy.sol
+++ b/contracts/MyStrategy.sol
@@ -458,8 +458,9 @@ contract MyStrategy is BaseStrategy, CurveSwapper, UniswapSwapper, TokenSwapPath
             _swapExactTokensForTokens(sushiswap, usdc, usdcToken.balanceOf(address(this)), getTokenSwapPath(usdc, cvxCrv));
         }
 
-        harvestData.cvxCrvHarvested = cvxCrvToken.balanceOf(address(this));
-        harvestData.cvxHarvsted = cvxToken.balanceOf(address(this));
+        // Initially set these to 0 - if the rewards are not more than the min nothing will get harvested.
+        harvestData.cvxCrvHarvested = 0;
+        harvestData.cvxHarvsted = 0;
 
         // 3. Sell 20% of accured rewards for underlying, then deposit remaining CVX / cvxCRV rewards into helper vaults and distribute
         if (cvxCrvRewardsPoolBalance > minCvxCrvRewardsPoolHarvest) {
@@ -548,7 +549,6 @@ contract MyStrategy is BaseStrategy, CurveSwapper, UniswapSwapper, TokenSwapPath
             _deposit(wantToDeposited);
         }
 
-        // totalWantAfter is the the balance of the pool, since all the want should have just been deposited.
         uint256 totalWantAfter = balanceOf();
         require(totalWantAfter >= totalWantBefore, "harvest-total-want-must-not-decrease");
 

--- a/contracts/MyStrategy.sol
+++ b/contracts/MyStrategy.sol
@@ -110,6 +110,11 @@ contract MyStrategy is BaseStrategy, CurveSwapper, UniswapSwapper, TokenSwapPath
     uint256 public autoCompoundingBps;
     uint256 public autoCompoundingPerformanceFeeGovernance;
 
+    uint256 public minCvxCrvRewardsPoolHarvest;
+    uint256 public minCvxRewardsPoolHarvest;
+    uint256 public minThreeCrvHarvest;
+    uint256 public minWantToDeposited;
+
     uint256 public constant AUTO_COMPOUNDING_BPS = 2000;
     uint256 public constant AUTO_COMPOUNDING_PERFORMANCE_FEE = 5000; // Proportion of auto-compounded rewards taken as fee
 
@@ -215,6 +220,12 @@ contract MyStrategy is BaseStrategy, CurveSwapper, UniswapSwapper, TokenSwapPath
         _initializeApprovals();
         autoCompoundingBps = 2000;
         autoCompoundingPerformanceFeeGovernance = 5000;
+
+        // Set default minimum pool harvests
+        minCvxCrvRewardsPoolHarvest = 0;
+        minCvxCrvRewardsPoolHarvest = 0;
+        minThreeCrvHarvest = 0;
+        minWantToDeposited = 0;
     }
 
     /// ===== Permissioned Functions =====
@@ -279,6 +290,19 @@ contract MyStrategy is BaseStrategy, CurveSwapper, UniswapSwapper, TokenSwapPath
     function setCurvePoolSwap(address _swap) external {
         _onlyGovernance();
         curvePool.swap = _swap;
+    }
+
+    function setMinPoolHarvest(
+        uint256 _minCvxCrvRewardsPoolHarvest,
+        uint256 _minCvxRewardsPoolHarvest,
+        uint256 _minThreeCrvHarvest,
+        uint256 _minWantToDeposited
+    ) external {
+        _onlyGovernance();
+        minCvxCrvRewardsPoolHarvest = _minCvxCrvRewardsPoolHarvest;
+        minCvxRewardsPoolHarvest = _minCvxRewardsPoolHarvest;
+        minThreeCrvHarvest = _minThreeCrvHarvest;
+        minWantToDeposited = _minWantToDeposited;
     }
 
     function _initializeApprovals() internal {
@@ -409,7 +433,8 @@ contract MyStrategy is BaseStrategy, CurveSwapper, UniswapSwapper, TokenSwapPath
         HarvestData memory harvestData;
 
         uint256 idleWant = IERC20Upgradeable(want).balanceOf(address(this));
-        uint256 totalWantBefore = balanceOf();
+        // Reuse call in idleWant, instead of calling again in balanceOf()
+        uint256 totalWantBefore = idleWant.add(balanceOfPool());
 
         // TODO: Harvest details still under constructuion. It's being designed to optimize yield while still allowing on-demand access to profits for users.
 
@@ -417,82 +442,94 @@ contract MyStrategy is BaseStrategy, CurveSwapper, UniswapSwapper, TokenSwapPath
         baseRewardsPool.getReward(address(this), true);
 
         uint256 cvxCrvRewardsPoolBalance = cvxCrvRewardsPool.balanceOf(address(this));
-        if (cvxCrvRewardsPoolBalance > 0) {
+        if (cvxCrvRewardsPoolBalance > minCvxCrvRewardsPoolHarvest) {
             cvxCrvRewardsPool.withdraw(cvxCrvRewardsPoolBalance, true);
         }
 
         uint256 cvxRewardsPoolBalance = cvxRewardsPool.balanceOf(address(this));
-        if (cvxRewardsPoolBalance > 0) {
+        if (cvxRewardsPoolBalance > minCvxRewardsPoolHarvest) {
             cvxRewardsPool.withdraw(cvxRewardsPoolBalance, true);
+        }
+
+        // 2. Convert 3CRV -> cvxCRV via USDC
+        uint256 threeCrvBalance = threeCrvToken.balanceOf(address(this));
+        if (threeCrvBalance > minThreeCrvHarvest) {
+            _remove_liquidity_one_coin(threeCrvSwap, threeCrvBalance, 1, 0);
+            _swapExactTokensForTokens(sushiswap, usdc, usdcToken.balanceOf(address(this)), getTokenSwapPath(usdc, cvxCrv));
         }
 
         harvestData.cvxCrvHarvested = cvxCrvToken.balanceOf(address(this));
         harvestData.cvxHarvsted = cvxToken.balanceOf(address(this));
 
-        // 2. Convert 3CRV -> cvxCRV via USDC
-        uint256 threeCrvBalance = threeCrvToken.balanceOf(address(this));
-        if (threeCrvBalance > 0) {
-            _remove_liquidity_one_coin(threeCrvSwap, threeCrvBalance, 1, 0);
-            _swapExactTokensForTokens(sushiswap, usdc, usdcToken.balanceOf(address(this)), getTokenSwapPath(usdc, cvxCrv));
-        }
-
-        // 3. Sell 20% of accured rewards for underlying
-        if (harvestData.cvxCrvHarvested > 0) {
+        // 3. Sell 20% of accured rewards for underlying, then deposit remaining CVX / cvxCRV rewards into helper vaults and distribute
+        if (cvxCrvRewardsPoolBalance > minCvxCrvRewardsPoolHarvest) {
+            harvestData.cvxCrvHarvested = cvxCrvToken.balanceOf(address(this));
             uint256 cvxCrvToSell = harvestData.cvxCrvHarvested.mul(autoCompoundingBps).div(MAX_FEE);
+            uint256 cvxCrvToDistribute = harvestData.cvxCrvHarvested.sub(cvxCrvToSell);
+            uint256 cvxCrvToStrategist = 0;
+            uint256 cvxCrvToGovernance = 0;
+
+            if (performanceFeeGovernance > 0) {
+                cvxCrvToGovernance = cvxCrvToDistribute.mul(performanceFeeGovernance).div(MAX_FEE);
+                cvxCrvHelperVault.depositFor(IController(controller).rewards(), cvxCrvToGovernance);
+                emit PerformanceFeeGovernance(IController(controller).rewards(), cvxCrv, cvxCrvToGovernance, block.number, block.timestamp);
+            }
+
+            if (performanceFeeStrategist > 0) {
+                cvxCrvToStrategist = cvxCrvToDistribute.mul(performanceFeeStrategist).div(MAX_FEE);
+                cvxCrvHelperVault.depositFor(strategist, cvxCrvToStrategist);
+                emit PerformanceFeeStrategist(strategist, cvxCrv, cvxCrvToStrategist, block.number, block.timestamp);
+            }
+
+            // TODO: [Optimization] Allow contract to circumvent blockLock to dedup deposit operations
+
+            // Sell 20% accrued rewards for underlying
             _swapExactTokensForTokens(sushiswap, cvxCrv, cvxCrvToSell, getTokenSwapPath(cvxCrv, wbtc));
+
+            // Deposit remaining to tree after taking fees.
+            // treeVaultPositionGained is the current balance, since it is all being deposited.
+            uint256 treeVaultPositionGained = cvxCrvToDistribute.sub(cvxCrvToGovernance).sub(cvxCrvToStrategist);
+            cvxCrvHelperVault.depositFor(badgerTree, treeVaultPositionGained);
+
+            emit TreeDistribution(address(cvxCrvHelperVault), treeVaultPositionGained, block.number, block.timestamp);
         }
 
-        if (harvestData.cvxHarvsted > 0) {
+        if (cvxRewardsPoolBalance > minCvxRewardsPoolHarvest) {
+            harvestData.cvxHarvsted = cvxToken.balanceOf(address(this));
             uint256 cvxToSell = harvestData.cvxHarvsted.mul(autoCompoundingBps).div(MAX_FEE);
+            uint256 cvxToDistribute = harvestData.cvxHarvsted.sub(cvxToSell);
+            uint256 cvxToStrategist = 0;
+            uint256 cvxToGovernance = 0;
+
+            if (performanceFeeGovernance > 0) {
+                cvxToGovernance = cvxToDistribute.mul(performanceFeeGovernance).div(MAX_FEE);
+                cvxHelperVault.depositFor(IController(controller).rewards(), cvxToGovernance);
+                emit PerformanceFeeGovernance(IController(controller).rewards(), cvx, cvxToGovernance, block.number, block.timestamp);
+            }
+
+            if (performanceFeeStrategist > 0) {
+                cvxToStrategist = cvxToDistribute.mul(performanceFeeStrategist).div(MAX_FEE);
+                cvxHelperVault.depositFor(strategist, cvxToStrategist);
+                emit PerformanceFeeStrategist(strategist, cvx, cvxToStrategist, block.number, block.timestamp);
+            }
+
+            // TODO: [Optimization] Allow contract to circumvent blockLock to dedup deposit operations
+
+            // Sell 20% accrued rewards for underlying
             _swapExactTokensForTokens(sushiswap, cvx, cvxToSell, getTokenSwapPath(cvx, wbtc));
+
+            // Deposit remaining to tree after taking fees.
+            // treeVaultPositionGained is the current balance, since it is all being deposited.
+            uint256 treeVaultPositionGained = cvxToDistribute.sub(cvxToGovernance).sub(cvxToStrategist);
+            cvxHelperVault.depositFor(badgerTree, treeVaultPositionGained);
+
+            emit TreeDistribution(address(cvxHelperVault), treeVaultPositionGained, block.number, block.timestamp);
         }
-
-        // Process extra rewards tokens
-        // Note: Assumes asset is ultimately swappable on Uniswap for underlying
-        // {
-        //     for (uint256 i = 0; i < extraRewards.length(); i=i+1) {
-        //         address token = extraRewards.at(i);
-        //         RewardTokenConfig memory rewardsConfig = rewardsTokenConfig[token];
-
-        //         /*
-        //         autoCompoundingBps = 30
-        //         autoCompoundingPerfFee = 10000
-        //         treeDistributionPerfFee = 0
-        //         */
-
-        //         IERC20Upgradeable tokenContract = IERC20Upgradeable(token);
-        //         uint256 tokenBalance = tokenContract.balanceOf(address(this));
-
-        //         // Sell compounding proportion to wbtc
-        //         uint256 amountToSell = tokenBalance.mul(rewardsConfig.autoCompoundingBps).div(MAX_FEE);
-        //         _swapExactTokensForTokens(uniswap, token, amountToSell, getTokenSwapPath(token, wbtc));
-
-        //         uint256 wbtcToDeposit = wbtcToken.balanceOf(address(this));
-
-        //         // TODO: Significant optimization by batching this will other curve deposit
-        //         _add_liquidity_single_coin(curvePool.swap, want, wbtc, wbtcToDeposit, curvePool.wbtcPosition, curvePool.numElements, 0);
-        //         uint256 wantGained = IERC20Upgradeable(want).balanceOf(address(this)).sub(idleWant);
-
-        //         uint256 autoCompoundedPerformanceFee = wantGained.mul(rewardsConfig.autoCompoundingPerfFee).div(MAX_FEE);
-        //         IERC20Upgradeable(want).transfer(IController(controller).rewards(), autoCompoundedPerformanceFee);
-        //         emit PerformanceFeeGovernance(IController(controller).rewards(), want, autoCompoundedPerformanceFee, block.number, block.timestamp);
-
-        //         // Distribute remainder to users
-        //         uint256 treeRewardBalanceBefore = tokenContract.balanceOf(badgerTree);
-
-        //         uint256 remainingRewardBalance = tokenContract.balanceOf(address(this));
-        //         tokenContract.safeTransfer(badgerTree, remainingRewardBalance);
-
-        //         uint256 treeRewardBalanceAfter = tokenContract.balanceOf(badgerTree);
-        //         uint256 treeRewardBalanceGained = treeRewardBalanceAfter.sub(treeRewardBalanceBefore);
-
-        //         emit TreeDistribution(token, treeRewardBalanceGained, block.number, block.timestamp);
-        //     }
-        // }
 
         // 4. Roll WBTC gained into want position
         uint256 wbtcToDeposit = wbtcToken.balanceOf(address(this));
-
+        uint256 wantToDeposited = 0;
+        
         if (wbtcToDeposit > 0) {
             _add_liquidity_single_coin(curvePool.swap, want, wbtc, wbtcToDeposit, curvePool.wbtcPosition, curvePool.numElements, 0);
             uint256 wantGained = IERC20Upgradeable(want).balanceOf(address(this)).sub(idleWant);
@@ -500,77 +537,22 @@ contract MyStrategy is BaseStrategy, CurveSwapper, UniswapSwapper, TokenSwapPath
             uint256 autoCompoundedPerformanceFee = wantGained.mul(autoCompoundingPerformanceFeeGovernance).div(MAX_FEE);
             IERC20Upgradeable(want).transfer(IController(controller).rewards(), autoCompoundedPerformanceFee);
             emit PerformanceFeeGovernance(IController(controller).rewards(), want, autoCompoundedPerformanceFee, block.number, block.timestamp);
+
+            wantToDeposited = idleWant.add(wantGained).sub(autoCompoundedPerformanceFee);
+        } else {
+            wantToDeposited = IERC20Upgradeable(want).balanceOf(address(this));
         }
 
-        // Deposit remaining want (including idle want) into strategy position
-        uint256 wantToDeposited = IERC20Upgradeable(want).balanceOf(address(this));
-
-        if (wantToDeposited > 0) {
+        // Deposit remaining want (including idle want) into strategy position if more than the minimum
+        if (wantToDeposited > minWantToDeposited) {
             _deposit(wantToDeposited);
         }
 
-        // 5. Deposit remaining CVX / cvxCRV rewards into helper vaults and distribute
-        if (harvestData.cvxCrvHarvested > 0) {
-            uint256 cvxCrvToDistribute = cvxCrvToken.balanceOf(address(this));
-
-            if (performanceFeeGovernance > 0) {
-                uint256 cvxCrvToGovernance = cvxCrvToDistribute.mul(performanceFeeGovernance).div(MAX_FEE);
-                cvxCrvHelperVault.depositFor(IController(controller).rewards(), cvxCrvToGovernance);
-                emit PerformanceFeeGovernance(IController(controller).rewards(), cvxCrv, cvxCrvToGovernance, block.number, block.timestamp);
-            }
-
-            if (performanceFeeStrategist > 0) {
-                uint256 cvxCrvToStrategist = cvxCrvToDistribute.mul(performanceFeeStrategist).div(MAX_FEE);
-                cvxCrvHelperVault.depositFor(strategist, cvxCrvToStrategist);
-                emit PerformanceFeeStrategist(strategist, cvxCrv, cvxCrvToStrategist, block.number, block.timestamp);
-            }
-
-            // TODO: [Optimization] Allow contract to circumvent blockLock to dedup deposit operations
-
-            uint256 treeHelperVaultBefore = cvxCrvHelperVault.balanceOf(badgerTree);
-
-            // Deposit remaining to tree after taking fees.
-            uint256 cvxCrvToTree = cvxCrvToken.balanceOf(address(this));
-            cvxCrvHelperVault.depositFor(badgerTree, cvxCrvToTree);
-
-            uint256 treeHelperVaultAfter = cvxCrvHelperVault.balanceOf(badgerTree);
-            uint256 treeVaultPositionGained = treeHelperVaultAfter.sub(treeHelperVaultBefore);
-
-            emit TreeDistribution(address(cvxCrvHelperVault), treeVaultPositionGained, block.number, block.timestamp);
-        }
-
-        if (harvestData.cvxHarvsted > 0) {
-            uint256 cvxToDistribute = cvxToken.balanceOf(address(this));
-
-            if (performanceFeeGovernance > 0) {
-                uint256 cvxToGovernance = cvxToDistribute.mul(performanceFeeGovernance).div(MAX_FEE);
-                cvxHelperVault.depositFor(IController(controller).rewards(), cvxToGovernance);
-                emit PerformanceFeeGovernance(IController(controller).rewards(), cvx, cvxToGovernance, block.number, block.timestamp);
-            }
-
-            if (performanceFeeStrategist > 0) {
-                uint256 cvxToStrategist = cvxToDistribute.mul(performanceFeeStrategist).div(MAX_FEE);
-                cvxHelperVault.depositFor(strategist, cvxToStrategist);
-                emit PerformanceFeeStrategist(strategist, cvx, cvxToStrategist, block.number, block.timestamp);
-            }
-
-            // TODO: [Optimization] Allow contract to circumvent blockLock to dedup deposit operations
-
-            uint256 treeHelperVaultBefore = cvxHelperVault.balanceOf(badgerTree);
-
-            // Deposit remaining to tree after taking fees.
-            uint256 cvxToTree = cvxToken.balanceOf(address(this));
-            cvxHelperVault.depositFor(badgerTree, cvxToTree);
-
-            uint256 treeHelperVaultAfter = cvxHelperVault.balanceOf(badgerTree);
-            uint256 treeVaultPositionGained = treeHelperVaultAfter.sub(treeHelperVaultBefore);
-
-            emit TreeDistribution(address(cvxHelperVault), treeVaultPositionGained, block.number, block.timestamp);
-        }
-
+        // totalWantAfter is the the balance of the pool, since all the want should have just been deposited.
         uint256 totalWantAfter = balanceOf();
         require(totalWantAfter >= totalWantBefore, "harvest-total-want-must-not-decrease");
 
         return harvestData;
     }
+
 }

--- a/contracts/MyStrategy.sol
+++ b/contracts/MyStrategy.sol
@@ -223,7 +223,7 @@ contract MyStrategy is BaseStrategy, CurveSwapper, UniswapSwapper, TokenSwapPath
 
         // Set default minimum pool harvests
         minCvxCrvRewardsPoolHarvest = 0;
-        minCvxCrvRewardsPoolHarvest = 0;
+        minCvxRewardsPoolHarvest = 0;
         minThreeCrvHarvest = 0;
         minWantToDeposited = 0;
     }

--- a/tests/test_custom.py
+++ b/tests/test_custom.py
@@ -2,14 +2,69 @@ import brownie
 from brownie import *
 from helpers.constants import MaxUint256
 from helpers.SnapshotManager import SnapshotManager
+from config import DEFAULT_WITHDRAWAL_FEE
 from helpers.time import days
 
-"""
-  TODO: Put your tests here to prove the strat is good!
-  See test_harvest_flow, for the basic tests
-  See test_strategy_permissions, for tests at the permissions level
-"""
+MAX_BASIS = 10000
 
 
-def test_my_custom_test(deployed):
-    assert False
+def test_is_profitable(deployed):
+    deployer = deployed.deployer
+    vault = deployed.vault
+    controller = deployed.controller
+    strategy = deployed.strategy
+    want = deployed.want
+    randomUser = accounts[6]
+
+    initial_balance = want.balanceOf(deployer)
+
+    settKeeper = accounts.at(vault.keeper(), force=True)
+
+    snap = SnapshotManager(vault, strategy, controller, "StrategySnapshot")
+
+    # Deposit
+    assert want.balanceOf(deployer) > 0
+
+    depositAmount = int(want.balanceOf(deployer) * 0.8)
+    assert depositAmount > 0
+
+    want.approve(vault.address, MaxUint256, {"from": deployer})
+
+    snap.settDeposit(depositAmount, {"from": deployer})
+
+    # Earn
+    with brownie.reverts("onlyAuthorizedActors"):
+        vault.earn({"from": randomUser})
+
+    min = vault.min()
+    max = vault.max()
+    remain = max - min
+
+    snap.settEarn({"from": settKeeper})
+
+    snap.settTend({"from": settKeeper})
+
+    chain.sleep(days(50))
+    chain.mine(10)
+
+    snap.settTend({"from": settKeeper})
+
+    snap.settHarvest({"from": deployer})
+    
+    snap.settWithdrawAll({"from": deployer})
+
+    ending_balance = want.balanceOf(deployer)
+
+    initial_balance_with_fees = initial_balance * (
+        1 - (DEFAULT_WITHDRAWAL_FEE / MAX_BASIS)
+    )
+
+    print("Initial Balance")
+    print(initial_balance)
+    print("initial_balance_with_fees")
+    print(initial_balance_with_fees)
+    print("Ending Balance")
+    print(ending_balance)
+
+    assert ending_balance > initial_balance_with_fees
+    assert false


### PR DESCRIPTION
Optimized the harvest function by trying to:
1) Remove extra variables like those regarding the treeVaultPosition
2) Limit the amount of balance checks (these are expensive!) and reuse/calculate when possible
3) Consolidate to limit balance checks and extra ifs

I added minimums for some of the harvests and the want deposit, since in the example transaction the amount removed from 3curve costs less than the gas! Initially these vars should be 0 but can be updated by governance using the setMinPoolHarvest() function. Note about the minimums, they are actually _right_ below the minimum; harvests run if the amount to harvest is greater than it. These vars are:
- minCvxCrvRewardsPoolHarvest
- minCvxRewardsPoolHarvest
- minThreeCrvHarvest
- minWantToDeposited


Gas Usage (using tests/test_custom.py and running tx.gas_usage):

Original - 5,547,060
Optimized<sup>0</sup> - 5,503,783
Optimized* - 81,216

<sup>0</sup> Setting all minimums to 0 so all harvests and deposits proceed. This shows a minimum savings of ~45,000 wei
* Setting all minimums to max uint256 - 1; nothing is harvested and nothing is deposited.



