### PR TITLE
Fee change test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -92,6 +92,13 @@ def deploy(sett_config):
     cvxCrvHelperGov = accounts.at(cvxCrvHelperVault.governance(), force=True)
     cvxCrvHelperVault.approveContractAccess(strategy.address, {"from": cvxCrvHelperGov})
 
+    ## Change governance fees to native (Council vote):
+    strategy.setAutoCompoundingPerformanceFeeGovernance(0, {"from": governance})
+    assert strategy.autoCompoundingPerformanceFeeGovernance() == 0
+    strategy.setPerformanceFeeGovernance(2000, {"from": governance})
+    assert strategy.performanceFeeGovernance() == 2000
+    console.print("[green]Autocompunding and governance fees were changed![/green]")
+
     ## Reset rewards if they are set to expire within the next 4 days or are expired already
     rewardsPool = interface.IBaseRewardsPool(strategy.baseRewardsPool())
     if rewardsPool.periodFinish() - int(time.time()) < days(4):

--- a/tests/examples/test_basic.py
+++ b/tests/examples/test_basic.py
@@ -25,6 +25,6 @@ def test_deploy_settings(sett_id):
 
     assert strategy.governance() == BADGER_DEV_MULTISIG
 
-    assert strategy.performanceFeeGovernance() == config.params.performanceFeeGovernance
+    assert strategy.performanceFeeGovernance() == 2000
     assert strategy.performanceFeeStrategist() == config.params.performanceFeeStrategist
     assert strategy.withdrawalFee() == config.params.withdrawalFee

--- a/tests/test_strategy_migration_live.py
+++ b/tests/test_strategy_migration_live.py
@@ -180,6 +180,14 @@ def test_migrate_staking_optimizer(
     console.print(f"StrategistPerformance: {strategy.performanceFeeStrategist()}")
     console.print(f"Withdrawal: {strategy.withdrawalFee()}")
 
+    ## Change governance fees to native (Council vote):
+    stratGov = accounts.at(newStrategy.governance(), force=True)
+    newStrategy.setAutoCompoundingPerformanceFeeGovernance(0, {"from": stratGov})
+    assert newStrategy.autoCompoundingPerformanceFeeGovernance() == 0
+    newStrategy.setPerformanceFeeGovernance(2000, {"from": stratGov})
+    assert newStrategy.performanceFeeGovernance() == 2000
+    console.print("[green]Autocompunding and governance fees were changed![/green]")
+
     # ==== Pre-Migration checks ==== #
 
     # Initial balance on New Strategy - In case there's any
@@ -282,6 +290,13 @@ def user_deposit_withdraw_harvest_flow(
     assert startingBalance >= depositAmount
     assert startingBalance >= 0
     # End Setup
+
+    ## Reset rewards if they are set to expire within the next 4 days or are expired already
+    rewardsPool = interface.IBaseRewardsPool(strategy.baseRewardsPool())
+    if rewardsPool.periodFinish() - int(time.time()) < days(4):
+        booster = interface.IBooster(strategy.booster())
+        booster.earmarkRewards(config.params.pid, {"from": randomUser})
+        console.print("[green]BaseRewardsPool expired or expiring soon - it was reset![/green]")
 
     # Run post migration flow
     snap.settEarn({"from": keeper})

--- a/tests/test_strategy_migration_live.py
+++ b/tests/test_strategy_migration_live.py
@@ -31,8 +31,6 @@ STRAT_KEYS = [
     "native.tricrypto2",
 ]
 
-HELPER_STRATS = ["native.cvx", "native.cvxCrv"]
-
 NEW_STRATEGIES = {
     "native.renCrv": "0x61e16b46F74aEd8f9c2Ec6CB2dCb2258Bdfc7071",
     "native.sbtcCrv": "0xCce0D2d1Eb2310F7e67e128bcFE3CE870A3D3a3d",


### PR DESCRIPTION
This PR includes changes to test the parameters change requested on the following badger-ape ticket https://github.com/Badger-Finance/badger-ape/issues/222

It calls the following on the strategies, both for the freshly deploy test and on the deployed strategies before migration on the migration test live:
```
strategy.setAutoCompoundingPerformanceFeeGovernance(0, {"from": governance})
strategy.setPerformanceFeeGovernance(2000, {"from": governance})
```

Additionally, the appropriate checks were added to the resolver. The changes make the strategy charge 0% instead od 10% fee on the generated want and 20% instead of 10% on the vault tokens obtained (bveCVX and vcvxCRV). All tests are passing with the changes, specially the migration live tests (first run failed for Tricrypto2 due to having an expired rewardpool):

![image](https://user-images.githubusercontent.com/25463788/140427027-9e4e91e8-c319-455e-9bf5-93686b975235.png)

The reset to the rewards pool was added at the beginning of the test and it passes now:

![image](https://user-images.githubusercontent.com/25463788/140427523-e408b206-dcd4-43e5-8acd-6269d384c395.png)

Should these changes be approved, they can be executed by ops_deployer2 before delegating governance of the strategies to the dev_multisig.

Use the following to run migration live tests:
```
 brownie test tests/test_strategy_migration_live.py -s
```