### PR TITLE
feat: sett actions simulation script

### DIFF
--- a/config/StrategyResolver.py
+++ b/config/StrategyResolver.py
@@ -262,6 +262,7 @@ class StrategyResolver(StrategyCoreResolver):
         entities["baseRewardsPool"] = self.manager.strategy.baseRewardsPool()
         entities["cvxHelperVault"] = convex_registry.cvxHelperVault
         entities["cvxCrvHelperVault"] = convex_registry.cvxCrvHelperVault
+        entities["VirtualBalanceRewardPool"] = convex_registry.VirtualBalanceRewardPool
 
         super().add_entity_balances_for_tokens(calls, tokenKey, token, entities)
         return calls

--- a/helpers/eth_registry.py
+++ b/helpers/eth_registry.py
@@ -11,6 +11,7 @@ multichain_registry = DotMap(eth_address="0xC564EE9f21Ed8A2d8E7e76c085740d5e4c5F
 convex_registry = DotMap(
     cvxHelperVault="0x53c8e199eb2cb7c01543c137078a038937a68e40",
     cvxCrvHelperVault="0x2B5455aac8d64C14786c3a29858E43b5945819C0",
+    VirtualBalanceRewardPool="0xAAf75a94394F6D06E01CcE62e2545CeFFBFA1E2D",
 )
 
 curve_registry = DotMap(

--- a/scripts/tests/simulate_sett_actions.py
+++ b/scripts/tests/simulate_sett_actions.py
@@ -1,0 +1,43 @@
+from helpers.SnapshotManager import SnapshotManager
+from brownie import (
+    StrategyConvexStakingOptimizer,
+    Controller,
+    SettV4,
+    accounts,
+    interface,
+)
+from rich.console import Console
+
+console = Console()
+
+"""
+Allows to simulate any of Harvest, Earn or Tend on a live instance of a Sett
+Use the following to run:
+
+brownie run scripts/tests/simulate_sett_actions.py main strategy_address action
+
+Where action can be: harvest, earn or tend.
+
+It defaults to simulating a harvest on the wiBTC/sBTC-f Sett
+"""
+
+
+def main(strategyAddress="0x6D4BA00Fd7BB73b5aa5b3D6180c6f1B0c89f70D1", action="harvest"):
+    strategy = StrategyConvexStakingOptimizer.at(strategyAddress)
+    want = interface.IERC20(strategy.want())
+    controller = Controller.at(strategy.controller())
+    vault = SettV4.at(controller.vaults(want.address))
+
+    strat_keeper = accounts.at(strategy.keeper(), force=True)
+    vault_keeper = accounts.at(vault.keeper(), force=True)
+
+    snap = SnapshotManager(vault, strategy, controller, "StrategySnapshot")
+
+    if action == "harvest":
+        snap.settHarvest({"from": strat_keeper})
+    elif action == "earn":
+        snap.settEarn({"from": vault_keeper})
+    elif action == "tend":
+        snap.settTend({"from": strat_keeper})
+    else:
+        console.print("[red]Action not recognized[/red]")


### PR DESCRIPTION
Script that allows to simulate any of Harvest, Earn or Tend on a live instance of a Sett.

Use the following to run:
```
brownie run scripts/tests/simulate_sett_actions.py main strategy_address action
```

Where action can be: harvest, earn or tend.
It defaults to simulating a harvest on the wiBTC/sBTC-f Sett